### PR TITLE
Downgrade Identity SDK to fix Azure AD authentication issue

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Calamari.Common" Version="14.8.1" />
     <PackageReference Include="Calamari.Scripting" Version="8.2.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.28.3" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="5.4.145" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Calamari/HealthCheckBehaviour.cs
+++ b/source/Calamari/HealthCheckBehaviour.cs
@@ -142,7 +142,7 @@ namespace Calamari.AzureServiceFabric
             var authResult = authContext.AcquireTokenAsync(
                                                            aad.ClusterApplication,
                                                            aad.ClientApplication,
-                                                           new UserPasswordCredential(aadUsername, aadPassword)).GetAwaiter().GetResult();
+                                                           new UserCredential(aadUsername, aadPassword)).GetAwaiter().GetResult();
             return authResult.AccessToken;
         }
 


### PR DESCRIPTION
The SDK was upgraded which caused a class name to change. We didn't catch the usage int the Powershell script.

Since we don't have a cluster w/Azure AD authentication setup yet, I've just rolled back the SDK version.

Fixes: https://github.com/OctopusDeploy/Issues/issues/6554