### PR TITLE
Update references to Calamari + Sashimi to match what Server 2020.6 is referencing

### DIFF
--- a/source/Calamari/App.config
+++ b/source/Calamari/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <runtime>
+        <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    </runtime>
+</configuration>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,8 +8,8 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="14.11.4" />
-    <PackageReference Include="Calamari.Scripting" Version="8.3.4" />
+    <PackageReference Include="Calamari.Common" Version="15.1.6" />
+    <PackageReference Include="Calamari.Scripting" Version="8.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.28.3" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="5.4.145" />
   </ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.3.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
   </ItemGroup>
 

--- a/source/Sashimi/Endpoints/AzureServiceFabricClusterEndpoint.cs
+++ b/source/Sashimi/Endpoints/AzureServiceFabricClusterEndpoint.cs
@@ -48,7 +48,7 @@ namespace Sashimi.AzureServiceFabric.Endpoints
             }
         }
 
-        public string DefaultWorkerPoolId { get; set; } = string.Empty;
+        public string? DefaultWorkerPoolId { get; set; } = string.Empty;
 
         public override IEnumerable<(string id, DocumentType documentType)> GetRelatedDocuments()
         {

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,7 +26,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.0.2" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.3.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="9.1.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,7 +26,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.1.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
   </ItemGroup>
 </Project>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.38.5" />
+</packages>


### PR DESCRIPTION
This PR merges the changes in https://github.com/OctopusDeploy/Sashimi.AzureServiceFabric/pull/5 to the main branch.

This ensures the versions referenced in Server 2020.6 for both Calamari And Sashimi packages match the Sashimi flavour package.