### PR TITLE
Update references to Calamari + Sashimi for targeting 2020.6 server

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="nunit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+        <PackageReference Include="nunit" Version="3.13.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="Shouldly" Version="3.0.2" />
     </ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,8 +8,8 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="16.0.7" />
-    <PackageReference Include="Calamari.Scripting" Version="8.6.2" />
+    <PackageReference Include="Calamari.Common" Version="17.0.1" />
+    <PackageReference Include="Calamari.Scripting" Version="8.6.4" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.28.3" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="5.4.145" />
   </ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -13,11 +13,11 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <ProjectReference Include="..\Sashimi\Sashimi.csproj" />
     <PackageReference Include="Assent" Version="1.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.2" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,7 +26,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.1" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.0" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,7 +26,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.2" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
This PR completes the work started in https://github.com/OctopusDeploy/Sashimi.AzureServiceFabric/pull/5

This PR increases the Calamari version to 17.0.1 (Server v2020.6 is still on Calamari v16.0.7), as part of merging this PR with the Server I will be bumping the Calamari version to match the one in this PR.

### Is it safe to bump Calamari to v17.0.1?
Yes I have reviewed the changes - https://github.com/OctopusDeploy/Calamari/compare/16.0.7...17.0.1