### PR TITLE
Bump to `Calamari.Common@19.4.6`

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,8 +8,8 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="19.2.5" />
-    <PackageReference Include="Calamari.Scripting" Version="13.3.0" />
+    <PackageReference Include="Calamari.Common" Version="19.4.6" />
+    <PackageReference Include="Calamari.Scripting" Version="13.3.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.28.3" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="5.4.145" />
   </ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,7 +26,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.2.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="13.3.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.2.1" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Overview

This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Change: OctopusDeploy/Calamari#754

Issue: OctopusDeploy/Issues#6941