### PR TITLE
Bump Calamari.Scripting to 14.1.1

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,8 +8,8 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="20.3.8" />
-    <PackageReference Include="Calamari.Scripting" Version="14.1.0" />
+    <PackageReference Include="Calamari.Common" Version="20.4.0" />
+    <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.28.3" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="5.4.145" />
   </ItemGroup>


### PR DESCRIPTION
Rolling dependency changes through to keep things up to date, no functional changes in this Sashimi as it's not a "Run a Script" step.

(Version bump results from fix for OctopusDeploy/Issues#7050, which changed the way Bash Script parameters are handled)