### PR TITLE
Bumps Calamari.* to 18.1.7, Sashimi.* to 9.0.3, Azure.Scripting to 11.0.3

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,8 +8,8 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="18.1.4" />
-    <PackageReference Include="Calamari.Scripting" Version="9.0.2" />
+    <PackageReference Include="Calamari.Common" Version="18.1.7" />
+    <PackageReference Include="Calamari.Scripting" Version="9.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.28.3" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="5.4.145" />
   </ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="12.1.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.2" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -27,6 +27,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Sashimi.AzureScripting" Version="11.0.2" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="9.0.2" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="9.0.3" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,7 +26,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.2" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.3" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="9.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.1.

Upstream changes:
* OctopusDeploy/Calamari#805
* OctopusDeploy/Sashimi#130
* OctopusDeploy/Sashimi.AzureScripting#18

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177